### PR TITLE
Add support for consul_#.#.#+ent versions.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,7 +15,7 @@ list_all () {
   local v
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" \
-      | grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-z]\+[0-9]*\)\?"); do
+      | grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)\?"); do
     version="${v#${toolname}_}"
     if [[ -z "${versions}" ]]; then
       versions="${version}"


### PR DESCRIPTION
consul is showing multiple versions
```
$ asdf list-all consul
1.4.1
1.4.1
1.4.2
1.4.2
```

Looking at the data it looks like consul has an enterprise version. 

```
$ curl -s "https://releases.hashicorp.com/consul/" | grep -E "\d+.\d+.\d+"
      margin: 0 0 50px;
    <a href="/consul/1.4.2/">consul_1.4.2</a>
    <a href="/consul/1.4.2+ent/">consul_1.4.2+ent</a>
    <a href="/consul/1.4.1+ent/">consul_1.4.1+ent</a>
    <a href="/consul/1.4.1/">consul_1.4.1</a>
```