### PR TITLE
test and document support for Boundary and Waypoint + fixes for Consul-related CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ script:
   - asdf list-all terraform
   - asdf list-all vault
   - asdf list-all waypoint
-  - asdf plugin-test boundary ./ 'boundary version'
-  - asdf plugin-test consul ./ 'consul version'
-  - asdf plugin-test nomad ./ 'nomad version'
-  - asdf plugin-test packer ./ 'packer version'
-  - asdf plugin-test serf ./ 'serf version'
-  - asdf plugin-test terraform ./ 'terraform version'
-  - asdf plugin-test vault ./ 'vault version'
-  - asdf plugin-test waypoint ./ 'waypoint version'
+  - asdf plugin-test boundary ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'boundary version'
+  - asdf plugin-test consul ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'consul version'
+  - asdf plugin-test nomad ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'nomad version'
+  - asdf plugin-test packer ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'packer version'
+  - asdf plugin-test serf ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'serf version'
+  - asdf plugin-test terraform ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'terraform version'
+  - asdf plugin-test vault ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'vault version'
+  - asdf plugin-test waypoint ./ --asdf-plugin-gitref $TRAVIS_COMMIT 'waypoint version'
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,30 @@ before_script:
   - git clone https://github.com/asdf-vm/asdf.git asdf
   - . asdf/asdf.sh
 script:
+  - asdf plugin-add boundary ./
   - asdf plugin-add consul ./
   - asdf plugin-add nomad ./
   - asdf plugin-add packer ./
   - asdf plugin-add serf ./
   - asdf plugin-add terraform ./
   - asdf plugin-add vault ./
+  - asdf plugin-add waypoint ./
+  - asdf list-all boundary
   - asdf list-all consul
   - asdf list-all nomad
   - asdf list-all packer
   - asdf list-all serf
   - asdf list-all terraform
   - asdf list-all vault
+  - asdf list-all waypoint
+  - asdf plugin-test boundary ./ 'boundary version'
   - asdf plugin-test consul ./ 'consul version'
   - asdf plugin-test nomad ./ 'nomad version'
   - asdf plugin-test packer ./ 'packer version'
   - asdf plugin-test serf ./ 'serf version'
   - asdf plugin-test terraform ./ 'terraform version'
   - asdf plugin-test vault ./ 'vault version'
+  - asdf plugin-test waypoint ./ 'waypoint version'
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ HashiCorp tools plugin for [asdf](https://github.com/asdf-vm/asdf) version manag
 ## Install
 
 ```
-asdf plugin-add consul|nomad|packer|serf|terraform|vault https://github.com/Banno/asdf-hashicorp.git
+asdf plugin-add boundary|consul|nomad|packer|serf|terraform|vault|waypoint https://github.com/Banno/asdf-hashicorp.git
 ```
 
 ## Use

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,7 +15,7 @@ list_all () {
   local v
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" \
-      | grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)\?"); do
+      | grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)*"); do
     version="${v#${toolname}_}"
     if [[ -z "${versions}" ]]; then
       versions="${version}"


### PR DESCRIPTION
This PR began as an effort to add tests and documentation for [Boundary](https://www.boundaryproject.io/) and [Waypoint](https://www.waypointproject.io/) - both tools are already supported by this plugin with no changes needed, so this is more a formality than anything else.

However, in the process of debugging some failing CI checks, I discovered two problems which needed to be addressed before the CI checks could pass:

1. Currently, the `list-all` command does not fully support versions with both a beta and an enterprise suffix. For example, the current latest version of consul is `1.9.0+ent-beta1`, but when using `list-all`, the version number is truncated and rendered as `1.9.0+ent`. That version doesn't exist and therefore fails to download.
1. The `asdf plugin-test` command attempts to check out the master branch of the repository by default, meaning that tests were being run against the master branch instead of the commit being tested. Luckily, there's a [`--asdf-plugin-gitref` flag
](https://asdf-vm.com/#/plugins-create?id=testing-plugins) which can be passed to the `plugin-test` command to run the test script against a specific commit.

I've included those two fixes in this PR for now, since the tests don't pass without them, but I'd be happy to break them out into a separate PR if you'd prefer!

Thanks for the great plugin!

---------
Related PRs to the asdf-plugins repo:

[Boundary](https://github.com/asdf-vm/asdf-plugins/pull/297)
[Waypoint](https://github.com/asdf-vm/asdf-plugins/pull/299)